### PR TITLE
Streams and netcdf fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
       <dependency>
          <groupId>fr.gael.drb</groupId>
          <artifactId>drbx-impl-netcdf</artifactId>
-         <version>1.0.21</version>
+         <version>1.0.22</version>
       </dependency>
       
       <dependency>


### PR DESCRIPTION
Update to last drbx-impl-netcdf and streams version.
These updates are fixing three issues:
 - bad int casting when not using cache in streams library (SD-2848)
 - fixing buffer usage in drbx-impl-netcdf library (SD-2830)
 - wrapping stream to implement the available method in drbx-impl-zip library (SD-2839 & SD-2891)